### PR TITLE
Deploy GCFs on Merge to Default Branch

### DIFF
--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -3,10 +3,6 @@ on:
   push:
     branches:
       - master
-    paths:
-      - "**.ts"
-      - "package.json"
-      - ".github/workflows/deploy-dev.yaml"
 jobs:
   deploy-dev:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -10,6 +10,6 @@ jobs:
       - uses: actions/checkout@v1
       - uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
         with:
-          version: "274.0.0"
+          version: "309.0.0"
           service_account_key: ${{ secrets.GCP_SA_KEY_DEV }}
       - run: gcloud functions deploy ${{ secrets.WEBHOOK_NAME }} --runtime nodejs8 --trigger-http --update-labels "app_hash=${{ github.sha}},app_name=handle_plan_webhook" --project=mabl-dev --entry-point=handlePlanWebhook --region us-central1 --allow-unauthenticated

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -10,6 +10,6 @@ jobs:
       - uses: actions/checkout@v1
       - uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
         with:
-          version: "274.0.0"
+          version: "309.0.0"
           service_account_key: ${{ secrets.GCP_SA_KEY_PROD }}
       - run: gcloud functions deploy ${{ secrets.WEBHOOK_NAME }} --runtime nodejs8 --trigger-http --update-labels "app_hash=${{ github.sha}},app_name=handle_plan_webhook" --project=mabl-prod --entry-point=handlePlanWebhook --region us-central1 --allow-unauthenticated


### PR DESCRIPTION
Presently dependency updates, (e.g. ~`package.json`~ `package-lock.json`) updates won't trigger deployments of this extension on merging pull requests. This update makes the trigger logic consistent with other GCF GitHub Actions repo workflows.