### PR TITLE
Update Dependencies to address CVEs

### DIFF
--- a/.github/workflows/build-and-maybe-deploy.yaml
+++ b/.github/workflows/build-and-maybe-deploy.yaml
@@ -42,7 +42,7 @@ jobs:
 
     - name: Auth to Dev
       if: github.ref == 'refs/heads/main'
-      uses: google-github-actions/setup-gcloud@master
+      uses: google-github-actions/setup-gcloud@v0
       with:
         project_id: 'mabl-dev'
         service_account_key: ${{ secrets.GCP_DEPLOY_SERVICE_ACCOUNT_MABL_DEV }}
@@ -66,7 +66,7 @@ jobs:
 
     - name: Auth to Prod
       if: contains(github.ref, 'refs/tags/')
-      uses: google-github-actions/setup-gcloud@master
+      uses: google-github-actions/setup-gcloud@v0
       with:
         project_id: 'mabl-prod'
         service_account_key: ${{ secrets.GCP_DEPLOY_SERVICE_ACCOUNT_MABL_PROD }}

--- a/.github/workflows/build-and-maybe-deploy.yaml
+++ b/.github/workflows/build-and-maybe-deploy.yaml
@@ -10,7 +10,7 @@ jobs:
   build-deploy-dev:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: actions/setup-node@v2
       with:
         node-version: '14.x' # Build on target deploy version

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,63 +4,58 @@
   "lockfileVersion": 1,
   "dependencies": {
     "@google-cloud/monitoring": {
-      "version": "2.1.5",
-      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/@google-cloud/monitoring/-/monitoring-2.1.5.tgz",
-      "integrity": "sha1-7UqWbM94HqAjjBklzWWaNvub5zo=",
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@google-cloud/monitoring/-/monitoring-2.3.5.tgz",
+      "integrity": "sha512-91+gobJMXEibKxnPOY3Q+ccFifQyRUdFpQ8uQ8acqWesxVj9ZH1VRm3ZpoleYWbbMe32cymhpGRamZ6t31veRQ==",
       "requires": {
-        "google-gax": "^2.9.2"
+        "google-gax": "^2.24.1"
       }
     },
     "@grpc/grpc-js": {
-      "version": "1.2.3",
-      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/@grpc/grpc-js/-/grpc-js-1.2.3.tgz",
-      "integrity": "sha1-Ndy8o8t0Fe9axuc9RAgOvLRKS+U=",
+      "version": "1.6.7",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/@grpc/grpc-js/-/grpc-js-1.6.7.tgz",
+      "integrity": "sha512-eBM03pu9hd3VqDQG+kHahiG1x80RGkkqqRb1Pchcwqej/KkAH95gAvKs6laqaHCycYaPK+TKuNQnOz9UXYA8qw==",
       "requires": {
-        "@types/node": "^12.12.47",
-        "google-auth-library": "^6.1.1",
-        "semver": "^6.2.0"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "12.19.12",
-          "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/@types/node/-/node-12.19.12.tgz",
-          "integrity": "sha1-BHk8KvpM6DOply5MR2Qy4w+d9Hs="
-        }
+        "@grpc/proto-loader": "^0.6.4",
+        "@types/node": ">=12.12.47"
       }
     },
     "@grpc/proto-loader": {
-      "version": "0.5.5",
-      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/@grpc/proto-loader/-/proto-loader-0.5.5.tgz",
-      "integrity": "sha1-ZyXnoYJ7346S4p+/Tp7wIDwJBqk=",
+      "version": "0.6.12",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/@grpc/proto-loader/-/proto-loader-0.6.12.tgz",
+      "integrity": "sha512-filTVbETFnxb9CyRX98zN18ilChTuf/C5scZ2xyaOTp0EHGq0/ufX8rjqXUcSb1Gpv7eZq4M2jDvbh9BogKnrg==",
       "requires": {
+        "@types/long": "^4.0.1",
         "lodash.camelcase": "^4.3.0",
-        "protobufjs": "^6.8.6"
+        "long": "^4.0.0",
+        "protobufjs": "^6.10.0",
+        "yargs": "^16.2.0"
       }
     },
     "@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-      "integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78="
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
     },
     "@protobufjs/base64": {
       "version": "1.1.2",
       "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/@protobufjs/base64/-/base64-1.1.2.tgz",
-      "integrity": "sha1-TIVzDlm5ofHzSQR9vyQpYDS7JzU="
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
     },
     "@protobufjs/codegen": {
       "version": "2.0.4",
       "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha1-fvN/DQEPsCitGtWXIuUG2SYoFcs="
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
     },
     "@protobufjs/eventemitter": {
       "version": "1.1.0",
       "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A="
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
     },
     "@protobufjs/fetch": {
       "version": "1.1.0",
       "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
       "requires": {
         "@protobufjs/aspromise": "^1.1.1",
         "@protobufjs/inquire": "^1.1.0"
@@ -69,32 +64,32 @@
     "@protobufjs/float": {
       "version": "1.0.2",
       "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/@protobufjs/float/-/float-1.0.2.tgz",
-      "integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E="
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
     },
     "@protobufjs/inquire": {
       "version": "1.1.0",
       "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik="
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
     },
     "@protobufjs/path": {
       "version": "1.1.2",
       "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/@protobufjs/path/-/path-1.1.2.tgz",
-      "integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0="
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
     },
     "@protobufjs/pool": {
       "version": "1.1.0",
       "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/@protobufjs/pool/-/pool-1.1.0.tgz",
-      "integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q="
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
     },
     "@protobufjs/utf8": {
       "version": "1.1.0",
       "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "@types/body-parser": {
-      "version": "1.19.0",
-      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/@types/body-parser/-/body-parser-1.19.0.tgz",
-      "integrity": "sha1-BoWzxH6zAG/+0RfN1VFkth+AU48=",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
+      "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
       "dev": true,
       "requires": {
         "@types/connect": "*",
@@ -102,30 +97,30 @@
       }
     },
     "@types/connect": {
-      "version": "3.4.34",
-      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/@types/connect/-/connect-3.4.34.tgz",
-      "integrity": "sha1-FwpAIjptZmAG2TyhKK8r6x2bGQE=",
+      "version": "3.4.35",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
+      "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
       "dev": true,
       "requires": {
         "@types/node": "*"
       }
     },
     "@types/express": {
-      "version": "4.17.9",
-      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/@types/express/-/express-4.17.9.tgz",
-      "integrity": "sha1-9fLfat1wP/KEKK3VK97IoQkbCng=",
+      "version": "4.17.13",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
+      "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
       "dev": true,
       "requires": {
         "@types/body-parser": "*",
-        "@types/express-serve-static-core": "*",
+        "@types/express-serve-static-core": "^4.17.18",
         "@types/qs": "*",
         "@types/serve-static": "*"
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.17.17",
-      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/@types/express-serve-static-core/-/express-serve-static-core-4.17.17.tgz",
-      "integrity": "sha1-a6AkZRZbbJw9jbOije9rFvybcPU=",
+      "version": "4.17.28",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.28.tgz",
+      "integrity": "sha512-P1BJAEAW3E2DJUlkgq4tOL3RyMunoWXqbSCygWo5ZIWTjUgN1YnaXWW4VWl/oc8vs/XoYibEGBKP0uZyF4AHig==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -134,48 +129,47 @@
       }
     },
     "@types/long": {
-      "version": "4.0.1",
-      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/@types/long/-/long-4.0.1.tgz",
-      "integrity": "sha1-RZxl+hhn2v5qjzIsTFFpVmPMVek="
+      "version": "4.0.2",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/@types/long/-/long-4.0.2.tgz",
+      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
     },
     "@types/mime": {
-      "version": "2.0.3",
-      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/@types/mime/-/mime-2.0.3.tgz",
-      "integrity": "sha1-yJO3NyHbc2mZQ7/DZTsd63+qSjo=",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
+      "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
       "dev": true
     },
     "@types/node": {
-      "version": "14.17.1",
-      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/@types/node/-/node-14.17.1.tgz",
-      "integrity": "sha1-Xgfgyy/3k6p6G0HernYiHmFmBJ8=",
-      "dev": true
+      "version": "14.18.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.20.tgz",
+      "integrity": "sha512-Q8KKwm9YqEmUBRsqJ2GWJDtXltBDxTdC4m5vTdXBolu2PeQh8LX+f6BTwU+OuXPu37fLxoN6gidqBmnky36FXA=="
     },
     "@types/qs": {
-      "version": "6.9.5",
-      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/@types/qs/-/qs-6.9.5.tgz",
-      "integrity": "sha1-Q0cRvdSete5p2QwdZ8NUqajssYs=",
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
+      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
       "dev": true
     },
     "@types/range-parser": {
-      "version": "1.2.3",
-      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/@types/range-parser/-/range-parser-1.2.3.tgz",
-      "integrity": "sha1-fuMwunyq+5gJC+zoal7kQRWQTCw=",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
+      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
       "dev": true
     },
     "@types/serve-static": {
-      "version": "1.13.8",
-      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/@types/serve-static/-/serve-static-1.13.8.tgz",
-      "integrity": "sha1-hREp1DRDPHCCFIV0/+wmPVgwnEY=",
+      "version": "1.13.10",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz",
+      "integrity": "sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==",
       "dev": true,
       "requires": {
-        "@types/mime": "*",
+        "@types/mime": "^1",
         "@types/node": "*"
       }
     },
     "abort-controller": {
       "version": "3.0.0",
       "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha1-6vVNU7YrrkE46AnKIlyEOabvs5I=",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
       "requires": {
         "event-target-shim": "^5.0.0"
       }
@@ -183,43 +177,79 @@
     "agent-base": {
       "version": "6.0.2",
       "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha1-Sf/1hXfP7j83F2/qtMIuAPhtf3c=",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
       "requires": {
         "debug": "4"
+      }
+    },
+    "ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+    },
+    "ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "requires": {
+        "color-convert": "^2.0.1"
       }
     },
     "arrify": {
       "version": "2.0.1",
       "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/arrify/-/arrify-2.0.1.tgz",
-      "integrity": "sha1-yWVekzHgq81YjSp8rX6ZVvZnAfo="
+      "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug=="
     },
     "base64-js": {
       "version": "1.5.1",
       "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha1-GxtEAWClv3rUC2UPCVljSBkDkwo="
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
     "bignumber.js": {
-      "version": "9.0.1",
-      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/bignumber.js/-/bignumber.js-9.0.1.tgz",
-      "integrity": "sha1-jXuhJMiCv9jkMmDGdHVRjQaJ5OU="
+      "version": "9.0.2",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/bignumber.js/-/bignumber.js-9.0.2.tgz",
+      "integrity": "sha512-GAcQvbpsM0pUb0zw1EI0KhQEZ+lRwR5fYaAp3vPOYuP7aDvGy6cVN6XHLauvF8SOga2y0dcLcjt3iQDTSEliyw=="
     },
     "buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
+    },
+    "cliui": {
+      "version": "7.0.4",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "requires": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "requires": {
+        "color-name": "~1.1.4"
+      }
+    },
+    "color-name": {
+      "version": "1.1.4",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "debug": {
-      "version": "4.3.1",
-      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/debug/-/debug-4.3.1.tgz",
-      "integrity": "sha1-8NIpxQXgxtjEmsVT0bE9wYP2su4=",
+      "version": "4.3.4",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "requires": {
         "ms": "2.1.2"
       }
     },
     "duplexify": {
-      "version": "4.1.1",
-      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/duplexify/-/duplexify-4.1.1.tgz",
-      "integrity": "sha1-cCfcN08VexIqiuCMLT6k0tlTqmE=",
+      "version": "4.1.2",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/duplexify/-/duplexify-4.1.2.tgz",
+      "integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
       "requires": {
         "end-of-stream": "^1.4.1",
         "inherits": "^2.0.3",
@@ -230,59 +260,74 @@
     "ecdsa-sig-formatter": {
       "version": "1.0.11",
       "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
-      "integrity": "sha1-rg8PothQRe8UqBfao86azQSJ5b8=",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
       "requires": {
         "safe-buffer": "^5.0.1"
       }
     },
+    "emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
     "end-of-stream": {
       "version": "1.4.4",
       "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/end-of-stream/-/end-of-stream-1.4.4.tgz",
-      "integrity": "sha1-WuZKX0UFe682JuwU2gyl5LJDHrA=",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "requires": {
         "once": "^1.4.0"
       }
     },
+    "escalade": {
+      "version": "3.1.1",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
+    },
     "event-target-shim": {
       "version": "5.0.1",
       "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha1-XU0+vflYPWOlMzzi3rdICrKwV4k="
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
     },
     "extend": {
       "version": "3.0.2",
       "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo="
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
     "fast-text-encoding": {
       "version": "1.0.3",
       "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/fast-text-encoding/-/fast-text-encoding-1.0.3.tgz",
-      "integrity": "sha1-7AKsjgGrijGa8YLa4mgSE8/pzlM="
+      "integrity": "sha512-dtm4QZH9nZtcDt8qJiOH9fcQd1NAgi+K1O2DbE6GG1PPCK/BWfOH3idCTRQ4ImXRUOyopDEgDEnVEE7Y/2Wrig=="
     },
     "gaxios": {
-      "version": "4.1.0",
-      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/gaxios/-/gaxios-4.1.0.tgz",
-      "integrity": "sha1-6K1GbbWkODxwudY7/RTfqofrAJk=",
+      "version": "4.3.3",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/gaxios/-/gaxios-4.3.3.tgz",
+      "integrity": "sha512-gSaYYIO1Y3wUtdfHmjDUZ8LWaxJQpiavzbF5Kq53akSzvmVg0RfyOcFDbO1KJ/KCGRFz2qG+lS81F0nkr7cRJA==",
       "requires": {
         "abort-controller": "^3.0.0",
         "extend": "^3.0.2",
         "https-proxy-agent": "^5.0.0",
         "is-stream": "^2.0.0",
-        "node-fetch": "^2.3.0"
+        "node-fetch": "^2.6.7"
       }
     },
     "gcp-metadata": {
-      "version": "4.2.1",
-      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/gcp-metadata/-/gcp-metadata-4.2.1.tgz",
-      "integrity": "sha1-MYSfvPkCXvNMIpfDKomh5+nyzWI=",
+      "version": "4.3.1",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/gcp-metadata/-/gcp-metadata-4.3.1.tgz",
+      "integrity": "sha512-x850LS5N7V1F3UcV7PoupzGsyD6iVwTVvsh3tbXfkctZnBnjW5yu5z1/3k3SehF7TyoTIe78rJs02GMMy+LF+A==",
       "requires": {
         "gaxios": "^4.0.0",
         "json-bigint": "^1.0.0"
       }
     },
+    "get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
+    },
     "google-auth-library": {
-      "version": "6.1.4",
-      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/google-auth-library/-/google-auth-library-6.1.4.tgz",
-      "integrity": "sha1-vHDE87ZoGuUnM0NGa87zdXe37kQ=",
+      "version": "7.14.1",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/google-auth-library/-/google-auth-library-7.14.1.tgz",
+      "integrity": "sha512-5Rk7iLNDFhFeBYc3s8l1CqzbEBcdhwR193RlD4vSNFajIcINKI8W8P0JLmBpwymHqqWbX34pJDQu39cSy/6RsA==",
       "requires": {
         "arrify": "^2.0.0",
         "base64-js": "^1.3.0",
@@ -296,46 +341,47 @@
       }
     },
     "google-gax": {
-      "version": "2.10.0",
-      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/google-gax/-/google-gax-2.10.0.tgz",
-      "integrity": "sha1-eRjlGU/jxfQzDMyzo7ZuNorHDY8=",
+      "version": "2.30.5",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/google-gax/-/google-gax-2.30.5.tgz",
+      "integrity": "sha512-Jey13YrAN2hfpozHzbtrwEfEHdStJh1GwaQ2+Akh1k0Tv/EuNVSuBtHZoKSBm5wBMvNsxTsEIZ/152NrYyZgxQ==",
       "requires": {
-        "@grpc/grpc-js": "~1.2.0",
-        "@grpc/proto-loader": "^0.5.1",
+        "@grpc/grpc-js": "~1.6.0",
+        "@grpc/proto-loader": "^0.6.12",
         "@types/long": "^4.0.0",
         "abort-controller": "^3.0.0",
         "duplexify": "^4.0.0",
         "fast-text-encoding": "^1.0.3",
-        "google-auth-library": "^6.1.3",
+        "google-auth-library": "^7.14.0",
         "is-stream-ended": "^0.1.4",
         "node-fetch": "^2.6.1",
-        "protobufjs": "^6.10.2",
+        "object-hash": "^3.0.0",
+        "proto3-json-serializer": "^0.1.8",
+        "protobufjs": "6.11.3",
         "retry-request": "^4.0.0"
       }
     },
     "google-p12-pem": {
-      "version": "3.0.3",
-      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/google-p12-pem/-/google-p12-pem-3.0.3.tgz",
-      "integrity": "sha1-ZzrDp105A6h/BYePPHXgb8FRZp4=",
+      "version": "3.1.4",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/google-p12-pem/-/google-p12-pem-3.1.4.tgz",
+      "integrity": "sha512-HHuHmkLgwjdmVRngf5+gSmpkyaRI6QmOg77J8tkNBHhNEI62sGHyw4/+UkgyZEI7h84NbWprXDJ+sa3xOYFvTg==",
       "requires": {
-        "node-forge": "^0.10.0"
+        "node-forge": "^1.3.1"
       }
     },
     "gtoken": {
-      "version": "5.1.0",
-      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/gtoken/-/gtoken-5.1.0.tgz",
-      "integrity": "sha1-S6jS/JqEWQmPdufo/Xvqo5/an+Q=",
+      "version": "5.3.2",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/gtoken/-/gtoken-5.3.2.tgz",
+      "integrity": "sha512-gkvEKREW7dXWF8NV8pVrKfW7WqReAmjjkMBh6lNCCGOM4ucS0r0YyXXl0r/9Yj8wcW/32ISkfc8h5mPTDbtifQ==",
       "requires": {
         "gaxios": "^4.0.0",
-        "google-p12-pem": "^3.0.3",
-        "jws": "^4.0.0",
-        "mime": "^2.2.0"
+        "google-p12-pem": "^3.1.3",
+        "jws": "^4.0.0"
       }
     },
     "https-proxy-agent": {
-      "version": "5.0.0",
-      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
-      "integrity": "sha1-4qkFQqu2inYuCghQ9sntrf2FBrI=",
+      "version": "5.0.1",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
       "requires": {
         "agent-base": "6",
         "debug": "4"
@@ -344,22 +390,27 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
     },
     "is-stream": {
-      "version": "2.0.0",
-      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/is-stream/-/is-stream-2.0.0.tgz",
-      "integrity": "sha1-venDJoDW+uBBKdasnZIc54FfeOM="
+      "version": "2.0.1",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="
     },
     "is-stream-ended": {
       "version": "0.1.4",
       "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/is-stream-ended/-/is-stream-ended-0.1.4.tgz",
-      "integrity": "sha1-9QIk6V4GvODjVtRApIJ801smfto="
+      "integrity": "sha512-xj0XPvmr7bQFTvirqnFr50o0hQIh6ZItDqloxt5aJrR4NQsYeSsyFQERYGCAzfindAcnKjINnwEEgLx4IqVzQw=="
     },
     "json-bigint": {
       "version": "1.0.0",
       "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/json-bigint/-/json-bigint-1.0.0.tgz",
-      "integrity": "sha1-rlR4I6wMrYOYZn+M2e9HMPWwH/E=",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
       "requires": {
         "bignumber.js": "^9.0.0"
       }
@@ -367,7 +418,7 @@
     "jwa": {
       "version": "2.0.0",
       "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/jwa/-/jwa-2.0.0.tgz",
-      "integrity": "sha1-p+nD8p2ulAJ+vK9Jl1yTRVk0EPw=",
+      "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
       "requires": {
         "buffer-equal-constant-time": "1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
@@ -377,7 +428,7 @@
     "jws": {
       "version": "4.0.0",
       "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/jws/-/jws-4.0.0.tgz",
-      "integrity": "sha1-LU6M9qMY/6oSYV6d7H6G5slzEPQ=",
+      "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
       "requires": {
         "jwa": "^2.0.0",
         "safe-buffer": "^5.0.1"
@@ -386,53 +437,64 @@
     "lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="
     },
     "long": {
       "version": "4.0.0",
       "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/long/-/long-4.0.0.tgz",
-      "integrity": "sha1-mntxz7fTYaGU6lVSQckvdGjVvyg="
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
     },
     "lru-cache": {
       "version": "6.0.0",
       "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha1-bW/mVw69lqr5D8rR2vo7JWbbOpQ=",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "requires": {
         "yallist": "^4.0.0"
       }
     },
-    "mime": {
-      "version": "2.4.7",
-      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/mime/-/mime-2.4.7.tgz",
-      "integrity": "sha1-lirtm+DtGckf19wuzl1/TompDXQ="
-    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha1-BFvTI2Mfdu0uK1VXM5RBa2OaAFI="
+      "version": "2.6.7",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      }
     },
     "node-forge": {
-      "version": "0.10.0",
-      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/node-forge/-/node-forge-0.10.0.tgz",
-      "integrity": "sha1-Mt6ir7Ppkm8C7lzoeUkCaRpna/M="
+      "version": "1.3.1",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/node-forge/-/node-forge-1.3.1.tgz",
+      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA=="
+    },
+    "object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw=="
     },
     "once": {
       "version": "1.4.0",
       "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "requires": {
         "wrappy": "1"
       }
     },
+    "proto3-json-serializer": {
+      "version": "0.1.9",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/proto3-json-serializer/-/proto3-json-serializer-0.1.9.tgz",
+      "integrity": "sha512-A60IisqvnuI45qNRygJjrnNjX2TMdQGMY+57tR3nul3ZgO2zXkR9OGR8AXxJhkqx84g0FTnrfi3D5fWMSdANdQ==",
+      "requires": {
+        "protobufjs": "^6.11.2"
+      }
+    },
     "protobufjs": {
-      "version": "6.10.2",
-      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/protobufjs/-/protobufjs-6.10.2.tgz",
-      "integrity": "sha1-uctr2OyPh1FFkro/39KOk/M6Rps=",
+      "version": "6.11.3",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/protobufjs/-/protobufjs-6.11.3.tgz",
+      "integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
       "requires": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -445,77 +507,142 @@
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.0",
         "@types/long": "^4.0.1",
-        "@types/node": "^13.7.0",
+        "@types/node": ">=13.7.0",
         "long": "^4.0.0"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "13.13.39",
-          "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/@types/node/-/node-13.13.39.tgz",
-          "integrity": "sha1-I30HH7WT06qpb2VajrL5Hg+xSAw="
-        }
       }
     },
     "readable-stream": {
       "version": "3.6.0",
       "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha1-M3u9o63AcGvT4CRCaihtS0sskZg=",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
       "requires": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
         "util-deprecate": "^1.0.1"
       }
     },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+    },
     "retry-request": {
-      "version": "4.1.3",
-      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/retry-request/-/retry-request-4.1.3.tgz",
-      "integrity": "sha1-1fdNryYTcs/1jQiwoZebTXyrD94=",
+      "version": "4.2.2",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/retry-request/-/retry-request-4.2.2.tgz",
+      "integrity": "sha512-xA93uxUD/rogV7BV59agW/JHPGXeREMWiZc9jhcwY4YdZ7QOtC7qbomYg0n4wyk2lJhggjvKvhNX8wln/Aldhg==",
       "requires": {
-        "debug": "^4.1.1"
+        "debug": "^4.1.1",
+        "extend": "^3.0.2"
       }
     },
     "safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha1-Hq+fqb2x/dTsdfWPnNtOa3gn7sY="
-    },
-    "semver": {
-      "version": "6.3.0",
-      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0="
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
     },
     "stream-shift": {
       "version": "1.0.1",
       "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/stream-shift/-/stream-shift-1.0.1.tgz",
-      "integrity": "sha1-1wiCgVWasneEJCebCHfaPDktWj0="
+      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
+    },
+    "string-width": {
+      "version": "4.2.3",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "requires": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      }
     },
     "string_decoder": {
       "version": "1.3.0",
       "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha1-QvEUWUpGzxqOMLCoT1bHjD7awh4=",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "requires": {
         "safe-buffer": "~5.2.0"
       }
     },
+    "strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "requires": {
+        "ansi-regex": "^5.0.1"
+      }
+    },
+    "tr46": {
+      "version": "0.0.3",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+    },
     "typescript": {
-      "version": "4.1.3",
-      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/typescript/-/typescript-4.1.3.tgz",
-      "integrity": "sha1-UZ1YK9lMugz4k0x9joRn5HP1O7c="
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.2.tgz",
+      "integrity": "sha512-Mamb1iX2FDUpcTRzltPxgWMKy3fhg0TN378ylbktPGPK/99KbDtMQ4W1hwgsbPAsG3a0xKa1vmw4VKZQbkvz5A=="
     },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
+    "webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+    },
+    "whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "requires": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "requires": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      }
+    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
+    "y18n": {
+      "version": "5.0.8",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
+    },
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha1-m7knkNnA7/7GO+c1GeEaNQGaOnI="
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "yargs": {
+      "version": "16.2.0",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "requires": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      }
+    },
+    "yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,11 +14,11 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@google-cloud/monitoring": "^2.1.5",
-    "typescript": "^4.1.3"
+    "@google-cloud/monitoring": "2.3.5",
+    "typescript": "4.7.2"
   },
   "devDependencies": {
-    "@types/express": "^4.17.9",
-    "@types/node": "^14.17.1"
+    "@types/express": "4.17.13",
+    "@types/node": "14.18.20"
   }
 }


### PR DESCRIPTION
- Update dependencies to address Dependabot warnings.
- CVE-2022-25878
- GHSA-5rrq-pxf6-6jx5
- GHSA-gf8q-jrpm-jvxq
- CVE-2022-0122
- CVE-2022-24773
- CVE-2022-24772
- Bump checkout action to latest
- Pin dependencies